### PR TITLE
Fix ZaloFloatingIcon component name

### DIFF
--- a/src/components/ZaloFloatingIcon.tsx
+++ b/src/components/ZaloFloatingIcon.tsx
@@ -1,8 +1,8 @@
-// src/components/CallToAction.tsx
+// src/components/ZaloFloatingIcon.tsx
 "use client";
 import { motion } from "framer-motion";
 
-export default function CallToAction() {
+export default function ZaloFloatingIcon() {
   return (
     <section className="py-10 bg-gradient-to-r from-indigo-600 to-blue-500 text-white text-center rounded-xl mx-4 md:mx-0">
       <h2 className="text-2xl md:text-3xl font-bold mb-4">Cần hỗ trợ? Đặt hàng ngay!</h2>


### PR DESCRIPTION
## Summary
- correct header comment for `ZaloFloatingIcon`
- rename the default export to `ZaloFloatingIcon`

## Testing
- `npm install`
- `npm run lint` *(fails: no-img-element warnings and several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee376acec8325912695da98906d48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the floating icon component to ZaloFloatingIcon for improved clarity. No changes to appearance or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->