### PR TITLE
Fix lint warnings, convert images to next Image

### DIFF
--- a/components/BannerSlider.tsx
+++ b/components/BannerSlider.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState, useRef } from "react";
+import Image from "next/image";
 
 const banners = [
   { img: "/images/ht228-banner-1.webp", alt: "Xốp nổ HT228 bảo vệ hàng hóa tuyệt đối" },
@@ -36,13 +37,14 @@ export default function BannerSlider() {
       onMouseLeave={() => setIsHover(false)}
     >
       {/* Ảnh banner */}
-      <img
+      <Image
         src={banners[current].img}
         alt={banners[current].alt}
+        width={1200}
+        height={320}
         className="w-full object-cover h-56 md:h-80 transition-all duration-700 scale-105 hover:scale-110 rounded-3xl select-none"
         draggable={false}
-        loading="eager"
-        fetchpriority="high"
+        priority
       />
       {/* Nút prev/next */}
       <button

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,12 +1,14 @@
 "use client";
+import Link from "next/link";
+
 export default function Navbar() {
   return (
     <nav className="w-full bg-white border-b py-3 flex space-x-8 px-4">
-      <a href="/">Trang chủ</a>
-      <a href="/san-pham">Sản phẩm</a>
-      <a href="/gioi-thieu">Giới thiệu</a>
-      <a href="/tin-tuc">Tin tức</a>
-      <a href="/khuyen-mai">Khuyến mãi</a>
+      <Link href="/">Trang chủ</Link>
+      <Link href="/san-pham">Sản phẩm</Link>
+      <Link href="/gioi-thieu">Giới thiệu</Link>
+      <Link href="/tin-tuc">Tin tức</Link>
+      <Link href="/khuyen-mai">Khuyến mãi</Link>
     </nav>
   );
 }

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,4 +1,3 @@
-/ src/components/CallToAction.tsx
 "use client";
 import { motion } from "framer-motion";
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
-/ src/components/Footer.tsx
 "use client";
+import Link from "next/link";
 
 export default function Footer() {
   return (
@@ -14,10 +14,26 @@ export default function Footer() {
         <div>
           <h3 className="font-bold mb-2">Điều hướng</h3>
           <ul className="space-y-1">
-            <li><a href="/" className="hover:underline">Trang chủ</a></li>
-            <li><a href="/san-pham" className="hover:underline">Sản phẩm</a></li>
-            <li><a href="/tin-tuc" className="hover:underline">Tin tức</a></li>
-            <li><a href="/lien-he" className="hover:underline">Liên hệ</a></li>
+            <li>
+              <Link href="/" className="hover:underline">
+                Trang chủ
+              </Link>
+            </li>
+            <li>
+              <Link href="/san-pham" className="hover:underline">
+                Sản phẩm
+              </Link>
+            </li>
+            <li>
+              <Link href="/tin-tuc" className="hover:underline">
+                Tin tức
+              </Link>
+            </li>
+            <li>
+              <Link href="/lien-he" className="hover:underline">
+                Liên hệ
+              </Link>
+            </li>
           </ul>
         </div>
         <div>

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -1,19 +1,14 @@
 "use client";
+import Link from "next/link";
 
-export default function ZaloFloatingIcon() {
+export default function Navbar() {
   return (
-    <a
-      href="https://zalo.me/738042415649016822"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="fixed bottom-6 right-6 z-50"
-    >
-      <img
-        src="/assets/images/zalo_oa.jpg"
-        alt="Zalo OA HT228"
-        className="w-14 h-14 rounded-full shadow-lg animate-bounce"
-      />
-    </a>
+    <nav className="w-full bg-white border-b py-3 flex space-x-8 px-4 sticky top-0 z-40">
+      <Link href="/">Trang chủ</Link>
+      <Link href="/san-pham">Sản phẩm</Link>
+      <Link href="/gioi-thieu">Giới thiệu</Link>
+      <Link href="/tin-tuc">Tin tức</Link>
+      <Link href="/khuyen-mai">Khuyến mãi</Link>
+    </nav>
   );
 }
-

--- a/src/components/HookIntro.tsx
+++ b/src/components/HookIntro.tsx
@@ -1,4 +1,3 @@
-/ src/components/HookIntro.tsx
 "use client";
 
 export default function HookIntro() {

--- a/src/components/NewsPromo.tsx
+++ b/src/components/NewsPromo.tsx
@@ -19,7 +19,7 @@ export default function NewsPromo() {
   return (
     <div className="w-full max-w-4xl mx-auto mt-2">
       <div className="bg-yellow-50 border-l-4 border-yellow-400 py-2 px-4 rounded-xl shadow flex flex-col gap-2 md:flex-row md:gap-6 items-center">
-        {promos.map((promo, idx) => (
+        {promos.map((promo) => (
           <a
             href={promo.link}
             key={promo.title}

--- a/src/components/PopupGHSV.tsx
+++ b/src/components/PopupGHSV.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 export default function PopupGHSV() {
   const [show, setShow] = useState(true);
@@ -29,9 +30,11 @@ export default function PopupGHSV() {
         >
           ×
         </button>
-        <img
+        <Image
           src="/images/ghsv_ht228.png"
           alt="Ưu đãi GHSV HT228"
+          width={160}
+          height={160}
           className="w-40 h-40 object-contain mb-2"
           draggable={false}
         />

--- a/src/components/TrustCircle3D.tsx
+++ b/src/components/TrustCircle3D.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { motion } from "framer-motion";
+import Image from "next/image";
 
 const trustIcons = [
   {
@@ -67,7 +68,7 @@ export default function TrustCircle3D() {
             >
               <div className="absolute inset-0 flex flex-col items-center justify-center" style={{ backfaceVisibility: "hidden" }}>
                 <div className="w-28 h-28 rounded-full overflow-hidden bg-white/80 shadow-2xl border-2 border-indigo-400 flex items-center justify-center mb-2 animate-spin-slow relative">
-                  <img src={t.front} alt={t.label} className="w-24 h-24 object-contain drop-shadow-lg" />
+                  <Image src={t.front} alt={t.label} width={96} height={96} className="w-24 h-24 object-contain drop-shadow-lg" />
                   <span className="absolute w-14 h-14 bg-white/20 left-2 top-2 rounded-full blur-2xl opacity-60 animate-pulse"></span>
                 </div>
                 <span className="font-bold text-blue-800 text-lg mt-3 mb-1 text-center tracking-tight drop-shadow">{t.label}</span>
@@ -78,7 +79,7 @@ export default function TrustCircle3D() {
                 style={{ transform: "rotateY(180deg)", backfaceVisibility: "hidden", filter: "drop-shadow(0 0 38px #42a5f5) blur(0.8px)" }}
               >
                 <div className="w-28 h-28 rounded-full overflow-hidden shadow-2xl bg-white flex items-center justify-center mb-3 border-2 border-indigo-400 relative">
-                  <img src={t.back} alt={`Mặt sau - ${t.label}`} className="w-24 h-24 object-cover" />
+                  <Image src={t.back} alt={`Mặt sau - ${t.label}`} width={96} height={96} className="w-24 h-24 object-cover" />
                   <span className="absolute w-12 h-12 bg-blue-400/20 right-3 bottom-1 rounded-full blur-2xl opacity-50 animate-pulse"></span>
                 </div>
                 <span className="text-xs text-blue-700 mt-1 font-semibold tracking-wide">Uy tín – bảo hành chính hãng</span>

--- a/src/components/ZaloFloatingIcon.tsx
+++ b/src/components/ZaloFloatingIcon.tsx
@@ -1,29 +1,21 @@
-// src/components/CallToAction.tsx
 "use client";
-import { motion } from "framer-motion";
+import Image from "next/image";
 
-export default function CallToAction() {
+export default function ZaloFloatingIcon() {
   return (
-    <section className="py-10 bg-gradient-to-r from-indigo-600 to-blue-500 text-white text-center rounded-xl mx-4 md:mx-0">
-      <h2 className="text-2xl md:text-3xl font-bold mb-4">Cần hỗ trợ? Đặt hàng ngay!</h2>
-      <p className="mb-6">Liên hệ qua Zalo OA hoặc gọi hotline để được tư vấn nhanh chóng.</p>
-      <div className="flex justify-center gap-4">
-        <motion.a
-          whileHover={{ scale: 1.05 }}
-          href="https://zalo.me/738042415649016822"
-          target="_blank"
-          className="px-6 py-3 bg-white text-indigo-600 font-semibold rounded-lg shadow hover:bg-gray-100 transition"
-        >
-          Nhắn Zalo ngay
-        </motion.a>
-        <motion.a
-          whileHover={{ scale: 1.05 }}
-          href="tel:0975257980"
-          className="px-6 py-3 bg-white text-indigo-600 font-semibold rounded-lg shadow hover:bg-gray-100 transition"
-        >
-          Gọi hotline
-        </motion.a>
-      </div>
-    </section>
+    <a
+      href="https://zalo.me/738042415649016822"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-6 right-6 z-50"
+    >
+      <Image
+        src="/assets/images/zalo_oa.jpg"
+        alt="Zalo OA HT228"
+        width={56}
+        height={56}
+        className="rounded-full shadow-lg animate-bounce"
+      />
+    </a>
   );
 }

--- a/src/types/aos.d.ts
+++ b/src/types/aos.d.ts
@@ -1,0 +1,1 @@
+declare module "aos";


### PR DESCRIPTION
## Summary
- fix stray lines and cleanup in components
- convert `<img>` tags to `next/image`
- switch nav links to `next/link`
- add missing `aos` type stub

## Testing
- `npm run lint`
- `npm run build` *(fails: Package path ./base is not exported from package tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_684ef261ae0c8325abd3e509bda9c883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved image loading performance and optimization by switching to Next.js's Image component in multiple areas, including banners, popups, and trust icons.
  - Enhanced navigation experience by updating navigation and footer links to use Next.js Link components for faster client-side routing.
  - Added TypeScript support for the "aos" animation library.

- **Refactor**
  - Simplified and redesigned the call-to-action section into a floating Zalo icon.
  - Updated and unified navigation bar design and structure.
  - Renamed and restructured components for clarity and consistency.

- **Style**
  - Improved navigation bar and footer styling for a more consistent look.

- **Chores**
  - Removed unused variables and outdated comments for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->